### PR TITLE
フレーム長の不変化

### DIFF
--- a/game.js
+++ b/game.js
@@ -270,7 +270,7 @@ Vue.createApp({
       for (let i = 0; i < 100; ++i) {
         const next = this.player.time + this.player.tickspeed;
         const currentTime2 = new Date().getTime();
-        if (currentTime2 - currentTime >= 8) { console.log(i); return; }
+        if (currentTime2 - currentTime >= 8) { return; }
         if (currentTime < next) { return; }
         this.player.time = next;
         this.update();

--- a/game.js
+++ b/game.js
@@ -49,7 +49,8 @@ const initialData = () => {
     challengecleared:[],
     challengebonuses:[],
 
-    levelitems:[0,0]
+    levelitems:[0,0],
+    time: new Date().getTime(),
 
   }
 }
@@ -122,7 +123,7 @@ Vue.createApp({
       autolevelnumber:new Decimal(2),
 
       shinepersent:0,
-
+      time: new Date().getTime(),
 
     }
   },
@@ -245,8 +246,6 @@ Vue.createApp({
       }
     },
 
-
-
     updateaccelerators(mu){
       for (let i = 1; i < 8; i++) {
         if(this.activechallengebonuses.includes(10)){
@@ -263,6 +262,18 @@ Vue.createApp({
       let val = new Decimal(11).pow(new Decimal(num).log10())
       this.updategenerators(new Decimal(val))
       this.updateaccelerators(new Decimal(val))
+    },
+    
+    updateFrame() {
+      const currentTime = new Date().getTime();
+      for (let i = 0; i < 100; ++i) {
+        const next = this.player.time + this.player.tickspeed;
+        const currentTime2 = new Date().getTime();
+        if (currentTime2 - currentTime >= 8) { console.log(i); return; }
+        if (currentTime < next) { return; }
+        this.player.time = next;
+        this.update();
+      }
     },
 
     update() {
@@ -302,8 +313,6 @@ Vue.createApp({
       }
 
       this.player.tickspeed = 1000 / this.player.accelerators[0].add(10).mul(amult).log10()
-
-      setTimeout(this.update, this.player.tickspeed);
     },
     exportsave(){
       this.exported = btoa(JSON.stringify(this.player))
@@ -328,6 +337,7 @@ Vue.createApp({
         saveData.acceleratorsBought = saveData.acceleratorsBought.map(v => new Decimal(v))
         while(saveData.acceleratorsCost.length<8)saveData.acceleratorsCost.push('0')
       }
+      saveData.time = Math.max(saveData.time, new Date().getTime() - 3600 * 1000);
       this.player = parseInt(saveData.saveversion) === version ?
         {
           money: new Decimal(saveData.money),
@@ -362,6 +372,7 @@ Vue.createApp({
           challengebonuses: saveData.challengebonuses ?? [],
 
           levelitems: saveData.levelitems ?? [0,0],
+          time: saveData.time ?? new Date().getTime(),
 
         } :
         readOldFormat(saveData);
@@ -624,8 +635,7 @@ Vue.createApp({
   },
   mounted() {
     this.load();
-
-    setTimeout(this.update, this.player.tickspeed);
+    setInterval(this.updateFrame, 16);
     setInterval(this.save, 2000);
   },
 }).mount('#app');
@@ -708,5 +718,6 @@ function readOldFormat(saveData) {
     challengebonuses: saveData.challengebonuses ?? [],
 
     levelitems: saveData.levelitems ?? [],
+    time: saveData.time ?? new Date().time(),
   }
 }

--- a/game.js
+++ b/game.js
@@ -266,6 +266,7 @@ Vue.createApp({
     
     updateFrame() {
       const currentTime = new Date().getTime();
+      this.player.time = Math.max(this.player.time, currentTime - 3600 * 1000);
       for (let i = 0; i < 100; ++i) {
         const next = this.player.time + this.player.tickspeed;
         const currentTime2 = new Date().getTime();
@@ -337,7 +338,6 @@ Vue.createApp({
         saveData.acceleratorsBought = saveData.acceleratorsBought.map(v => new Decimal(v))
         while(saveData.acceleratorsCost.length<8)saveData.acceleratorsCost.push('0')
       }
-      saveData.time = Math.max(saveData.time, new Date().getTime() - 3600 * 1000);
       this.player = parseInt(saveData.saveversion) === version ?
         {
           money: new Decimal(saveData.money),


### PR DESCRIPTION
# 実装機能
* 間隙に関わらず処理の更新が16ms秒ごとになるように設定
* データに更新時刻を持たせる, ない場合は現在時刻を設定
* 更新時刻との差分を元に更新回数を判定するように設定
* 1フレームでの更新回数が最大8ms/100回になるように設定 (line: 270, 273)
* データの更新時刻が1時間以上前の時、1時間前となるように設定 (line: 269)

# それによる改善
* Javascriptのバックグラウンド処理で処理が遅れた時に、時刻を考慮した回数の処理が実施される。
* ブラウザを閉じた時に最大1時間分の処理をオフライン処理として実施される (スペックによるが間隙33で60秒程度)
* 間隙の変動によってFPSが変わらないため、間隙の変更に対して強くなることの期待 (一律62.5fps)
